### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["شركة Ankitects المملوكة المحدودة ومتطوعون"]
 language = "ar"
-multilingual = false
 src = "src"
 title = "دليل استخدام أنكي"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10