### PR TITLE
Make highlighted search filters bidirectionally isolated

### DIFF
--- a/css/rtl.css
+++ b/css/rtl.css
@@ -8,3 +8,6 @@ code { direction: ltr; }
 h1:target::before, h2:target::before, h3:target::before, h4:target::before, h5:target::before, h6:target::before {
     margin-left: -10px !important;
 }
+.hljs {
+    unicode-bidi: plaintext;
+}


### PR DESCRIPTION
Since highlighted search filters in `anki-manual/searching.html` are not necessarily right-to-left like parent, setting `unicode-bidi` property is useful to give them a separate direction. `plaintext` value gives them direction based on textual content.

Some search filters are confusing because of being right-to-left. e.g.:
<img width="580" height="161" alt="image" src="https://github.com/user-attachments/assets/da0a2bcb-bd2b-466c-b269-876530354368" />
After:
<img width="560" height="149" alt="image" src="https://github.com/user-attachments/assets/3aa35d7e-25bd-4bd8-8935-385a100e1ff0" />
 